### PR TITLE
Fixes bug #866

### DIFF
--- a/mailer.js
+++ b/mailer.js
@@ -36,6 +36,11 @@ module.exports = function (config) {
         port: parseInt(smtp.port, 10)
       };
 
+			// enable secureConnection is port is 465 to use encrypted handshake
+			if (smtpConfig.port == 465) {
+				smtpConfig.secureConnection = true;
+			}
+
       // allow anonymous SMTP login if user and pass are not defined
       if (smtp.auth && smtp.auth.user && smtp.auth.pass) {
         smtpConfig.auth = {


### PR DESCRIPTION
Port 465 expects encrypted connection so unless secureConnection parameter supplied to nodemailer SMTP servers running on port 465 is not working. 

This pull request checks port and set that parameter.